### PR TITLE
fix: remove semicolon after CSS rule

### DIFF
--- a/src/main/resources/META-INF/frontend/styles/image-crop-styles.css
+++ b/src/main/resources/META-INF/frontend/styles/image-crop-styles.css
@@ -20,4 +20,4 @@
 
 .img-full-height img {
     height: 100vh;
-};
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a CSS styling issue to ensure images display properly with full height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->