### PR TITLE
deprecate: deprecate `ImageCrop(Image)` constructor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.flowingcode.vaadin.addons</groupId>
     <artifactId>image-crop-addon</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <name>Image Crop Add-on</name>
     <description>Image Crop Add-on for Vaadin Flow</description>
     <url>https://www.flowingcode.com/en/open-source/</url>

--- a/src/main/java/com/flowingcode/vaadin/addons/imagecrop/ImageCrop.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/imagecrop/ImageCrop.java
@@ -68,7 +68,10 @@ public class ImageCrop extends ReactAdapterComponent {
    * Constructs an ImageCrop component with the given image.
    *
    * @param image the image to be cropped
+   * @deprecated This constructor only preserves the image URL and {@linkplain #setImageAlt(String)
+   *             alternate text}. Use {@link #ImageCrop(String)} instead.
    */
+  @Deprecated(forRemoval = true, since = "1.2.0")
   public ImageCrop(Image image) {
     this(image.getSrc());
     image.getAlt().ifPresent(a -> this.setImageAlt(a)); 


### PR DESCRIPTION
Close #24 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project version to 1.2.0-SNAPSHOT.

* **Deprecations**
  * Marked the constructor that accepts an Image object as deprecated and updated its documentation to recommend using the constructor that accepts a String instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->